### PR TITLE
기한만료 채용정보(무박 2일 해커톤) 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,6 @@
 
 구직 중인 신입 개발자들의 취업에 큰 도움이 될 해커톤 정보도 포함했습니다. ([JBee 한재엽](https://github.com/JaeYeopHan)님 감사합니다.)
 
-* [06.12 ~ 06.30] [무박 2일 해커톤 (AskDjango에서 주최, 한국 마이크로소프트에서 협찬)](https://nomade.kr/moim/askdjango-hackathon-2017/)
-
 
 ## Special Thanks
 


### PR DESCRIPTION
기한만료 채용정보(무박 2일 해커톤) 삭제입니다.