### PR TITLE
리디 데이터 엔지니어 신입/경력 -> 경력으로 변경.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@
 
 ### 추천 스타트업
 
-* [채용시까지] [리디북스 데이터 엔지니어 신입/경력](https://jobs.smartrecruiters.com/RIDICorp/743999663041844)
 * [채용시까지] [오마이트립 개발자 채용](http://www.ohmylab.com/recruit.html)
   * [CTO이신 이규원님 페이스북](https://www.facebook.com/gyuwon.yi?fref=ufi&pnref=story)
   * [경력 서버 개발자](http://www.ohmylab.com/recruit.html#server-programmer)


### PR DESCRIPTION
리디 데이터 엔지니어 채용공고에

자격 요건
핵심 직무 역량
- 백엔드 또는 데이터 엔지니어링 개발 경력 5년 이상

이 추가되었습니다.
신입채용이 사라진 것으로 보입니다.