### PR TITLE
Nexon Korea 상반기 인턴 추가...

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@
 채용에 올라온 기업들은 모두 **개발자로서 커리어 쌓기가 좋은 회사**의 **신입/주니어** 채용을 기준으로 합니다.  
 
 > 유의미한 트래픽이 발생하고,  
-코드리뷰, 배포 자동화 등이 구축되어 있고,  
-코드 품질에 관심이 있는 회사를 얘기합니다.
+> 코드리뷰, 배포 자동화 등이 구축되어 있고,  
+> 코드 품질에 관심이 있는 회사를 얘기합니다.
 
 보통 잡플래닛 평점 3.3 미만인 회사들은 PR을 주셔도 추가해드릴 수 없습니다.  
 이 저장소의 목적은 **양질의 취업정보를 한 곳에 모으기 위함**입니다.  
@@ -133,7 +133,9 @@
 
 ### 추천 기업
 
-* [채용시까지] [넥슨](https://career.nexon.com/user/recruit/notice/noticeList)
+- [11.20 ~ 12.03][NEXON 상반기 인턴](https://career.nexon.com/user/recruit/notice/noticeList?joinCorp=NX)
+
+* [채용시까지][넥슨](https://career.nexon.com/user/recruit/notice/noticeList)
   * [데브캣 - 게임 클라이언트 개발](https://career.nexon.com/user/recruit/notice/noticeView?joinCorp=NX&reNo=20170127)
 
 * [채용시까지] [카카오/다음](https://careers.kakao.com/jobs)


### PR DESCRIPTION
Nexon 2018년 상반기 동계 인턴을 추가합니다.

Jobplanet 평점: 3.5점,
게임 프로그래밍, 게임 기획, IT 엔지니어, 해외/모바일 사업 분야를 모집하고 있습니다.