### PR TITLE
라인플러스 채용공고 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@
 
 ### 추천 기업
 
-- [03.02 ~ 03.19][라인플러스 개발 신입 공채](https://www.facebook.com/linecareers/photos/a.1685076581715369.1073741828.1685072095049151/2131442770412079/?type=3&theater)
+- [03.02 ~ 03.19][라인플러스 개발 신입 공채](https://recruit.linepluscorp.com/lineplus/career/detail/20001509?classId=&entTypeCd=&page=)
 - [01.17 ~ 채용시까지][큐브리드(오픈소스 DBMS) 신입 개발자 채용](http://www.cubrid.com/recruit/3815218)
 - [02.01 ~ 채용시까지][LINE PLUS | App. Prototype 개발 인턴 채용](https://recruit.linepluscorp.com/lineplus/career/detail/20001423?classId=&entTypeCd=&page=)
 


### PR DESCRIPTION
정식 채용공고가 올라와 페이스북 링크를 대체하려고 합니다.