### PR TITLE
[Add] 네이버 AI 해커톤 2018 목록을 추가한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@
 
 ### 추천 기업
 
-- [03.02 ~ 03.19] [라인플러스 개발 신입 공채](https://recruit.linepluscorp.com/lineplus/career/detail/20001509?classId=&entTypeCd=&page=)
+- [03.02 ~ 03.19][라인플러스 개발 신입 공채](https://recruit.linepluscorp.com/lineplus/career/detail/20001509?classId=&entTypeCd=&page=)
 - [03.07 ~ 03.23] [비사이드 소프트 신입 개발 공채](http://www.bsidesoft.com/?p=6086)
   * [2016 공채후기 1](https://www.facebook.com/notes/hika-maeng/16%EB%85%84%EB%8F%84-%EC%8B%A0%EC%9E%85%EC%82%AC%EC%9B%90-%EA%B3%B5%EC%B1%84%EB%8B%B4-1-2/1047729105294588/)
   * [2016 공채후기 2](https://www.facebook.com/notes/hika-maeng/16%EB%85%84%EB%8F%84-%EC%8B%A0%EC%9E%85%EC%82%AC%EC%9B%90-%EA%B3%B5%EC%B1%84%EB%8B%B4-2-2/1048174391916726/)
@@ -188,6 +188,8 @@
 ### 채용 연계 프로그래밍 대회 일정
 
 ### 해커톤 일정
+
+- [03.09~03.25][NAVER AI Hackathon 2018](http://d2.naver.com/news/8195394)
 
 ## Special Thanks
 


### PR DESCRIPTION
3월 9일부터 3월 25일까지 서류접수가 가능한 네이버 AI 해커톤 2018 목록을 추가하였습니다 :)