### PR TITLE
Delete: Tip > lecture (is Deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,6 @@
 
 * [StiKuan(김대희)님의 기술면접 자료 Repository](https://github.com/StiKuan/StiKuan-Review)
 
-* [코딩 인터뷰 완벽 준비 (유료 동영상 강의)](https://www.udemy.com/draft/993276/learn/v4/t/lecture/6057896?start=0)
-
 ### 기타 정보
 
 * [2016 KSUG 경력 관리 세미나](http://jojoldu.tistory.com/24)


### PR DESCRIPTION
해당 강좌는 더 이상 지원되지 않기때문에 기존 구매자만 볼 수 있습니다.
링크가 잘못된건지해서 해당 강좌를 검색하여 찾아봤으나 유데미에 존재하지 않습니다.
이점 확인해보시면 좋을 것 같습니다