### PR TITLE
야놀자 백엔드 채용 타이틀에서 '신입' 제거, 오타 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
   * [(참고자료) 냉정과 열정사이](https://brunch.co.kr/@leehosung/34)
   * [(참고자료) 두숟갈 스터디를 마치며](https://brunch.co.kr/@leehosung/42)
 * [채용시까지] [VCNC(Between) 채용 리스트](https://www.wanted.co.kr/company/1053)
-* [채용시까지] [야놀자 신입/경력 백엔드 개발자 채용](https://www.jobplanet.co.kr/companies/89637/job_postings/74380/%EB%B0%B1%EC%97%94%EB%93%9C-%EC%84%9C%EB%B2%84-%EA%B0%9C%EB%B0%9C%EC%9E%90/%EC%95%BC%EB%86%80%EC%9E%90)
+* [채용시까지] [야놀자 경력 백엔드 개발자 채용](https://www.jobplanet.co.kr/companies/89637/job_postings/74380/%EB%B0%B1%EC%97%94%EB%93%9C-%EC%84%9C%EB%B2%84-%EA%B0%9C%EB%B0%9C%EC%9E%90/%EC%95%BC%EB%86%80%EC%9E%90)
 * [채용시까지] [NBT(캐시슬라이드) 신입 개발자 채용](http://nbt.com/junior-developer신입개발자/)
 
 ### 이외 채용정보 얻는법
@@ -99,7 +99,7 @@
 
 * [진유림님의 이직 이야기](https://milooy.wordpress.com/2018/02/07/moving-job/)
 
-* [이종립(akka. 기계인간)님의 SI탈출하기 세미나 by OKKY](http://jojoldu.tistory.com/247)
+* [이종립(aka. 기계인간)님의 SI탈출하기 세미나 by OKKY](http://jojoldu.tistory.com/247)
 
 * [이한별님의 구직 이야기](http://lhb0517.tistory.com/entry/reviewofjojoldu)
 


### PR DESCRIPTION
- 야놀자 신입/경력 백엔드 개발자 채용 링크에 접속해보니 신입 개발자 채용은 마감된 상태였습니다.
  * [야놀자 IT인터넷 신입 채용 공고(마감된 공고 포함)](https://www.jobplanet.co.kr/companies/89637/job_postings?utf8=%E2%9C%93&occupation_id=11600&occupation_level2_id=&recruitment_type_id=1&city_id=&show_ended=true&order_by=recent)
  * [플랫폼실](https://www.jobplanet.co.kr/companies/89637/job_postings/247230/%EB%B0%B1%EC%97%94%EB%93%9C%EA%B0%9C%EB%B0%9C%EC%9E%90-%ED%94%8C%EB%9E%AB%ED%8F%BC%EC%8B%A4/%EC%95%BC%EB%86%80%EC%9E%90)
  * [CX서비스실](https://www.jobplanet.co.kr/companies/89637/job_postings/219482/%EB%B0%B1%EC%97%94%EB%93%9C-%EA%B0%9C%EB%B0%9C%EC%9E%90-cx%EC%84%9C%EB%B9%84%EC%8A%A4%EC%8B%A4/%EC%95%BC%EB%86%80%EC%9E%90)  
따라서 해당 타이틀을 **야놀자 경력 백엔드 개발자 채용**으로 바꾸었습니다.
- 이종립(aaka. 기계인간)님의 SI 탈출하기 세미나 by OKKY 타이틀에서 akka가 as knwon as의 의미로 쓰인게 맞다면 akka는 aka를 오타내신게 아닐까 생각됩니다.