### PR TITLE
노리 신입 개발자 링크 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 ### 추천 스타트업
 
-* [채용시까지] [노리 웹 서버 개발자(신입)](https://github.com/Knowre-Dev/WebDevCurriculum)
+* [채용시까지] [노리 웹 서버 개발자(신입)](https://www.wanted.co.kr/wd/10386?referer_id=143226)
   * [노리 웹 개발 신입 커리큘럼](https://github.com/Knowre-Dev/WebDevCurriculum)
   * [노리 CTO님 개발 블로그](http://blog.kivol.net/)
 


### PR DESCRIPTION
노리 웹 서버 개발자(신입)가 커리큘럼의 링크로 설정되어 있어서 찾아 가기 쉽게 원티드 채용 링크로 수정했습니다.