### PR TITLE
종료된 채용 공고 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@
 
 ### 추천 기업
 
-* [04.30 ~ 05.13] [우아한 테크캠프](https://www.facebook.com/woowahanTech/photos/a.1925530564354206.1073741828.1916460261927903/2042363582670903/?type=3&theater)
-* [04.23 ~ 05.13] [카카오게임즈 ](https://kakaogames.recruiter.co.kr/app/jobnotice/view?systemKindCode=MRS2&jobnoticeSn=1541)
 * [04.30 ~ 05.20] [2018 eBay Korea Summer Internship](https://ebaykorea.recruiter.co.kr/bbs/appsite/notice/read/64990)
 * [05.07 ~ 05.20] [줌인터넷 포털서비스 개발](https://zuminternet.recruiter.co.kr/app/jobnotice/view?systemKindCode=MRS2&jobnoticeSn=1599)
 


### PR DESCRIPTION
우아한 테크캠프와 카카오 게임즈 채용 공고가 끝나서 삭제했습니다.