### PR TITLE
블로그로 이동하게 되어 있어 해당 회사의 채용공고 페이지로 이동하도록 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   * [지그재그 트래픽](http://ppss.kr/archives/151825)
   * [지그재그 아웃스탠딩](http://outstanding.kr/zigzag20170123/)
 
-* [채용시까지] [데이블 신입 채용](http://blog.dable.io/221245564421)
+* [채용시까지] [데이블 신입 채용](http://dable.io/ko/careers/)
   * [웹 개발자 신입](http://blog.naver.com/PostThumbnailView.nhn?blogId=teamdable&logNo=221237837766&categoryNo=10&parentCategoryNo=10&from=postList)
   * [Devops 엔지니어 신입/경력/병특](http://blog.dable.io/221237876850)
   * [데이터 분석가 신입/경력/병특](http://blog.dable.io/221237870373)


### PR DESCRIPTION
블로그로 이동하게 되어 있는 URL을 해당 회사의 채용공고 페이지로 이동하도록 수정했습니다.