### PR TITLE
2017 카카오 코드 페스티벌 해설 추가 및 링크 정렬 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@
 
 * [2016 KSUG 경력 관리 세미나](http://bit.ly/2JEexjS)
 
+* [T아카데미 토크 ON 세미나](https://tacademy.skplanet.com/front/tacademy/courseinfo/campus.action)
+
 * [프로그래머의 삶님의 IT 분야의 개발자로 취업할 때 실수하는 몇 가지](http://coderlife.tistory.com/88)
 
 * [나무위키 SI](https://namu.wiki/w/SI)

--- a/README.md
+++ b/README.md
@@ -184,8 +184,6 @@
 
 * [2016 KSUG 경력 관리 세미나](http://bit.ly/2JEexjS)
 
-* [T아카데미 토크 ON 세미나](https://tacademy.skplanet.com/front/tacademy/courseinfo/campus.action)
-
 * [프로그래머의 삶님의 IT 분야의 개발자로 취업할 때 실수하는 몇 가지](http://coderlife.tistory.com/88)
 
 * [나무위키 SI](https://namu.wiki/w/SI)

--- a/README.md
+++ b/README.md
@@ -190,15 +190,11 @@
 
 * [피해야 하는 중소기업 거르는 꿀팁](http://principlesofknowledge.kr/archives/31414)
 
-* [2017 카카오 블라인드 코딩테스트 1차 해설](http://tech.kakao.com/2017/09/27/kakao-blind-recruitment-round-1/)
+* 2017 카카오 코드 페스티벌 [예선전](http://tech.kakao.com/2017/08/11/code-festival-round-1/), [본선](http://tech.kakao.com/2017/09/14/code-festival-round-2/) 해설
 
-* [2017 카카오 블라인드 코딩테스트 2차 해설](http://tech.kakao.com/2017/10/24/kakao-blind-recruitment-round-2/)
+* 2017 카카오 블라인드 코딩테스트 [1차](http://tech.kakao.com/2017/09/27/kakao-blind-recruitment-round-1/), [2차](http://tech.kakao.com/2017/10/24/kakao-blind-recruitment-round-2/), [3차](http://tech.kakao.com/2017/11/14/kakao-blind-recruitment-round-3/) 해설
 
-* [2017 카카오 블라인드 코딩테스트 3차 해설](http://tech.kakao.com/2017/11/14/kakao-blind-recruitment-round-3/)
-
-* [2018 카카오 코드 페스티벌 예선전 해설](http://tech.kakao.com/2018/08/09/code-festival-2018-round-1/)
-
-* [2018 카카오 코드 페스티벌 본선 해설](http://tech.kakao.com/2018/09/12/code-festival-2018-round-2/)
+* 2018 카카오 코드 페스티벌 [예선전](http://tech.kakao.com/2018/08/09/code-festival-2018-round-1/), [본선](http://tech.kakao.com/2018/09/12/code-festival-2018-round-2/) 해설
 
 * [Java Interview Question (영문)](https://www.javatpoint.com/corejava-interview-questions)
 


### PR DESCRIPTION
2017 카카오 코드 페스티벌 예선전, 본선 해설을 추가했습니다.
그리고 카카오 코딩 테스트 해설 링크가 계속 추가되면 너무 길어질 것 같아서 정렬을 수정해봤습니다. :)
감사합니다.