### PR TITLE
라인 웍스 모바일 채용전제형 인턴 공고 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 * [채용시까지] [MyMusicTaste Frontend 개발자 채용](http://bit.ly/2OOayk8)
   * [MyMusicTaste 개발문화](https://github.com/MyMusicTaste/recruit)
   * [기술 블로그](https://mymusictaste.github.io/)
+* [~ 2018.12.02 23:59:59] [2018 Works Mobile SW개발/서비스 부문 채용전제형 인턴 모집](https://bit.ly/2DyfA1s)
   
 ### 이외 채용정보 얻는법
 

--- a/db.json
+++ b/db.json
@@ -24,6 +24,11 @@
             "endDate": "채용시까지",
             "link": "http://bit.ly/2IfFcQK",
             "description": "MyMusicTaste 프론트엔드 개발 신입 채용"
+        },
+        {
+            "endDate": "~ 2018.12.02 23:59:59",
+            "link": "https://bit.ly/2DyfA1s",
+            "description": "2018 Works Mobile SW개발/서비스 부문 채용전제형 인턴 모집"
         }
     ],
     "seminars": [


### PR DESCRIPTION
라인 웍스 모바일 채용전제형 인턴 공고 추가하였습니다.
다행히도 [잡플래닛 평점](https://www.jobplanet.co.kr/companies/312497/reviews/%EC%9B%8D%EC%8A%A4%EB%AA%A8%EB%B0%94%EC%9D%BC)이 3.5네요 ^^;

다만 채용 공고가 js호출로 표시되는 방식이라 링크를 가져올 수가 없어서 전체 채용공고 링크로 대체하였습니다.
![image](https://user-images.githubusercontent.com/20942871/48710537-00ce7480-ec4c-11e8-9a4c-7a0b7e8f5e56.png)


