### PR TITLE
Fix broken link to contributors page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![author](https://img.shields.io/badge/author-jojoldu-ff69b4.svg?style=flat-square)](https://jojoldu.tistory.com/)
 [![Build Status](https://travis-ci.org/jojoldu/junior-recruit-scheduler.svg?branch=master)](https://travis-ci.org/jojoldu/junior-recruit-scheduler)
-[![CONTRIBUTORS](https://img.shields.io/badge/contributors-25-green.svg?style=flat-square)](https://github.com/jojoldu/junior-recruit-scheduler/blob/master/CONTRIBUTING.md)
+[![CONTRIBUTORS](https://img.shields.io/badge/contributors-25-green.svg?style=flat-square)](https://github.com/jojoldu/junior-recruit-scheduler/graphs/contributors)
 [![HitCount](http://hits.dwyl.io/jojoldu/junior-recruit-scheduler.svg)](http://hits.dwyl.io/jojoldu/junior-recruit-scheduler)
 
 <a href="https://github.com/jojoldu/junior-recruit-scheduler/graphs/contributors"><img src="https://opencollective.com/junior-recruit-scheduler/contributors.svg?width=720"></a>


### PR DESCRIPTION
존재하지 않는 링크를 제거하고, 유효한 링크로 연결했습니다.

기존에 연결되어 있던 기여 가이드 파일이 삭제된 듯 하여, 기여자 그래프 페이지로 변경했습니다.