### PR TITLE
네이버 핵데이 행사의 접수기간 만료

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@
 ### 채용 관련 행사
 
 채용과 관련된 프로그래밍 대회, 해커톤 일정, 세미나 등을 포함합니다.
-* [~ 2019.04.04 23:59:59] [2019 NAVER CAMPUS HACKDAY SUMMER](https://github.com/NAVER-CAMPUS-HACKDAY/common)
 
 ### 이외 채용정보 얻는법
 

--- a/db.json
+++ b/db.json
@@ -57,10 +57,5 @@
     }
   ],
   "seminars": [
-    {
-      "endDate": "~ 2019.04.04 23:59:59",
-      "link": "https://github.com/NAVER-CAMPUS-HACKDAY/common",
-      "description": "2019 NAVER CAMPUS HACKDAY SUMMER"
-    }
   ]
 }


### PR DESCRIPTION
네이버 핵데이 행사의 접수기간 만료된 것으로 보여서 삭제했어요.