### PR TITLE
접수 마감된 모집 공고 제거

### DIFF
--- a/README-en_EN.md
+++ b/README-en_EN.md
@@ -26,9 +26,9 @@ I highly recommend you to do your portfolio and personal projects with Springboo
 
 ## 1. Introduction
 
-It's a repository for **good quality employment information** for junior developers. 
-I'd like to include an intern/new/junior recruitment & hackathon schedule. 
-The period means **closing of documents**. 
+It's a repository for **good quality employment information** for junior developers.
+I'd like to include an intern/new/junior recruitment & hackathon schedule.
+The period means **closing of documents**.
 (If you find out that the recruitment has been completed, please make a Pull Request.)
 
 ## 2. PR Rules
@@ -54,17 +54,15 @@ The facebook page which communize informations such as technology/seminar for ju
 Every notice of employment in this chapter is for **new/junior** from **a good company for developers to build a career**.
 
 > Significant traffic occurs,
-Have Code Reviews, Continuous Deployment, etc. 
+Have Code Reviews, Continuous Deployment, etc.
 Refers to a company interested in code quality.
 
 Companies with a JobPlanet rating of 3.3 or less can't add to it even if you give them PR.
-The purpose of this repository is to gather **good quality employment information** in one place. 
+The purpose of this repository is to gather **good quality employment information** in one place.
 **I'm not trying to contain all the company's recruitment information**.  
 If there is a company that has low JobPlanet ratings but you really want to recommend it, please leave the reason for that in PR.
 
 ### Recommended Company
-
-* [2020.01.08 00:00:00 ~ Undetermined] [Coupang 2020 the first halft junior developer public recruitment (Java, Android, iOS)](https://grnh.se/e3e7aa821)
 
 * [Undetermined] [당근마켓(Carrot Market) New/Intern Backend/Platform developer recruitment](https://www.notion.so/07ca1fda22584d60a48ef43a8cf9bab0)
   * [Technical blog](https://medium.com/daangn)
@@ -113,12 +111,12 @@ Includes recruiting-related programming contests, hackathon schedules, seminars,
 
 ### How to get employment information
 
-**Personally, I don't recommend recruitment information for Job Korea or people..**. 
+**Personally, I don't recommend recruitment information for Job Korea or people..**.
 
 
 **잡코리아, 사람인 채용 정보는 개인적으로는 추천하지 않습니다**.  
 You may skip any additional forms or comments that appear to be copy & paste into your employment information.
-If **the companys are not interested in hiring as much, you can think that they don't have enough understanding of the developer**. 
+If **the companys are not interested in hiring as much, you can think that they don't have enough understanding of the developer**.
 Below are the JobPlanet/Wanted search criteria that I visit regularly.
 I'd like you to refer to it.
 

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -60,8 +60,6 @@
 
 ### 推荐公司
 
-* [2020.01.08 00:00:00 ~ 到结束为止] [Coupang 2020年上半年新进开发商公开招聘 (Java, Android, iOS)](https://grnh.se/e3e7aa821)
-
 * [招聘中] [당근마켓 后端/平台 新手/实习生 招聘](https://www.notion.so/07ca1fda22584d60a48ef43a8cf9bab0)
   * [博客](https://medium.com/daangn)
 * [招聘中] [ZIGZAG iOS/Android 新手](http://bit.ly/2JpPLob)
@@ -131,7 +129,7 @@
 * [스타트업 주의 사항](https://www.facebook.com/dalinaum/posts/10157321350303468)
 
 * [MS Imagine Cup 국가대표의 스타트업 도전기 - 창업 실패부터 현재 커리어를 만들기까지 - 참석후기](https://jojoldu.tistory.com/423)
-  
+
 * [当你的面试通过了一个你不喜欢的小公司](https://jojoldu.tistory.com/398)
 
 * [Tech HR - 阅读初级开发人员和高级开发人员之间的差异](https://jojoldu.tistory.com/163)

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@
     * [Front-end 개발자 채용 **(노션 버전)**](https://www.notion.so/movill/679cc5f594e348c9b81789cc0694f062)
     * [사내 기술 스택](https://stackshare.io/kakao-movill/movill)
 
-* [2020.01.08 00:00:00 ~ TO 소진시까지] [쿠팡 2020 상반기 신입 개발자 공개채용 (Java, Android, iOS)](https://grnh.se/e3e7aa821)
-
 * [채용시까지] [데브시스터즈 개발자 전분야 채용](https://careers.devsisters.com/)
   * [2020년 전문연구요원/산업기능요원 채용](https://careers.devsisters.com/position/adhoc/2020/expert-research)
       * 게임 서버 / 게임 클라이언트 / 웹 프론트엔드,백엔드 / Data Scientist / Machine Learning / 모바일 앱(Android, iOS)

--- a/db.json
+++ b/db.json
@@ -11,11 +11,6 @@
 			"description": "카카오 모빌 웹프론트엔드 인턴 채용"
 		},
 		{
-			"endDate": "TO마감시까지",
-			"link": "https://grnh.se/e3e7aa821",
-			"description": "쿠팡 2020 상반기 신입 개발자 공개채용 (Java, Android, iOS)"
-		},
-		{
 			"endDate": "채용시까지",
 			"link": "https://careers.devsisters.com/position/adhoc/2020/expert-research/",
 			"description": "데브시스터즈 전문연구요원/산업기능요원 채용"


### PR DESCRIPTION
쿠팡 상반기 신입 공채 공고 링크가 존재하지 않아 해당 공고를 제거합니다.