### PR TITLE
마감된 채용공고 수정, 네이버 예약 플랫폼 인턴 추가 요청

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@
 
 ### 추천 기업 (마감일)
 
-* [2020.05.08 00:00:00 ~ 2020.05.21 14:00:00] [2020 NCSOFT SUMMER INTERN 모집](https://careers.ncsoft.com/apply/list?utm_source=https://github.com/jojoldu/junior-recruit-scheduler)
-
 * [2020.05.04 00:00:00 ~ 2020.05.24 18:00:00] [네이버 웹툰 하계 인턴십](https://bit.ly/2yPE06j)
+
+* [2020.05.21 00:00:00 ~ 2020.06.10 23:59:59] [네이버 예약 플랫폼 개발 인턴십](http://bitly.kr/n4eBsropK
+)
 
 ### 추천 기업 (수시 채용)
 


### PR DESCRIPTION
오늘 마감된 nc 인턴십  공고를 삭제하고, 
오늘 나온 네이버 예약 플랫폼 프론트엔드/백엔드 개발 인턴십(채용연계형)을 추가했습니다.