### PR TITLE
네이버 인턴 추가 및 유형 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@
 
 * [2020.07.20 00:00:00 ~ 2020.07.29 23:59:59] [토스 3년차 이하 개발자 채용](https://toss.im/career/next-developer-2020)
 
-* [2020.07.20 00:00:00 ~ 2020.08.02 18:00:00] [네이버 웹툰 개발 인턴](https://bit.ly/2WzbbDO)
+* [2020.07.20 00:00:00 ~ 2020.08.02 18:00:00] [네이버 웹툰 개발 체험형 인턴](https://bit.ly/2WzbbDO)
+
+* [2020.07.20 00:00:00 ~ 2020.08.02 18:00:00] [네이버 웹툰 개발/리서치 인턴 (채용 연계형)](https://recruit.webtoonscorp.com/webtoon/ko/job/detail?annoId=20004253&classId=170&jobId=&classNm=&searchTxt=&jobKeyword=&page=)
 
 * [2020.06.08 00:00:00 ~ 2020.09.08 23:59:59] [네이버 AI기반 글로벌 추천 서비스 신입 개발자 모집](https://recruit.navercorp.com/naver/job/detail/developer?annoId=20004095&classId=&jobId=&entTypeCd=001&searchTxt=%EB%B9%85%EB%8D%B0%EC%9D%B4%ED%84%B0&searchSysComCd=)
 

--- a/db.json
+++ b/db.json
@@ -6,9 +6,14 @@
 			"description": "토스 3년차 이하 개발자 채용"
 		},
 		{
-			"endDate":"2020.08.02 18:00:009",
+			"endDate":"2020.08.02 18:00:00",
 			"link": "https://bit.ly/2WzbbDO",
-			"description": "네이버 웹툰 개발 인턴"
+			"description": "네이버 웹툰 개발 체험형 인턴"
+		},
+		{
+			"endDate":"2020.08.02 18:00:00",
+			"link": "https://recruit.webtoonscorp.com/webtoon/ko/job/detail?annoId=20004253&classId=170&jobId=&classNm=&searchTxt=&jobKeyword=&page=",
+			"description": "네이버 웹툰 개발/리서치 인턴 (채용 연계형)"
 		},		
 		{
 			"endDate":"2020.09.08 23:59:59",


### PR DESCRIPTION
안녕하세요.
네이버 공고를 자세히 살펴보니 체험형 인턴 이외에도,
리서치분야를 포함한 채용연계형 인턴도 있더라구요.

그래서 좀 더 구체적으로 유형과 채용연계형 인턴을 추가해봤습니다.
또한 db.json에 일정 시간에 오타가 있는 것 같아서 그 부분도 수정하였습니다. 

풀 리퀘스트가 아직 미흡하여서 검토 잘 부탁드립니다.
감사합니다.