### PR TITLE
마감된 네이버 동영상 플랫폼 (인턴) 공고 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@
   - **1억 대의 디바이스. 100만 RPM. 하루 10억 건 이상의 이벤트 데이터**를 다루는 데이터 기업.  
     (GS SHOP 등 [100+ 개의 기업](https://abit.ly/ab180-clients)이 제품 사용중)
   - [어떤 문화와 동료를 지향하나요?](https://abit.ly/ab180-culture)
-- [채용시까지] [네이버 동영상 플랫폼 (인턴)](https://recruit.navercorp.com/naver/job/detail/developer?annoId=20003170&utm_source=jojoldu/junior-recruit-scheduler)
 
 * [상시채용] [모두의싸인 주니어 개발자 채용](https://www.notion.so/61da1be2959b40ae8621f1bdc44d605b?utm_source=junior-recruit-scheduler)
 

--- a/db.json
+++ b/db.json
@@ -27,11 +27,6 @@
 		},
 		{
 			"endDate": "채용시까지",
-			"link": "https://recruit.navercorp.com/naver/job/detail/developer?annoId=20003170&utm_source=junior-recruit-scheduler",
-			"description": "네이버 동영상 플랫폼 (인턴)"
-		},
-		{
-			"endDate": "채용시까지",
 			"link": "https://www.notion.so/fee06e9581f542a4898f803a9a601603",
 			"description": "CODEF 주니어 개발자 채용"
 		},


### PR DESCRIPTION
안녕하세요

"네이버 동영상 플랫폼 (인턴)" 공고의 링크가 끊겻고,
네이버 커리어에서도 찾을 수 없어서 마감으로 판단하여 삭제했습니다.