### PR TITLE
나무위키 SI 문서 링크 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@
 - [개발자 채용시 기술검증 어떻게 할 것인가 - 세미나 후기](http://bit.ly/2QDKlWs)
 - [2016 KSUG 경력 관리 세미나](http://bit.ly/2JEexjS)
 - [프로그래머의 삶님의 IT 분야의 개발자로 취업할 때 실수하는 몇 가지](http://coderlife.tistory.com/88)
-- [나무위키 SI](https://namu.wiki/w/SI)
 - [피해야 하는 중소기업 거르는 꿀팁](http://principlesofknowledge.kr/archives/31414)
 
 - [Java Interview Question (영문)](https://www.javatpoint.com/corejava-interview-questions)


### PR DESCRIPTION
SI 직링크가 아닐 뿐더러 다른 정보들과 동등한 정도의 양질의 정보라고 생각할 수 없기 때문에 삭제를 제안합니다.