### PR TITLE
인프런 채용링크 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,4 +299,3 @@
 ### 추천 도서
 
 - [프로그래밍 면접 이렇게 준비한다](https://book.naver.com/bookdb/book_detail.nhn?bid=15064639)
-  - [요약정리](https://www.slideshare.net/ddayinhwang9/ss-60152650)

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@
 ### 추천 기업 (수시 & 상시 채용)
 
 - [채용시까지] [인프런 백엔드 / 프론트엔드 신입, 경력 개발자](https://inflab.notion.site/d96215b0d4d44f62ba65c88120c999c5)
-  - [백엔드 개발자 (NodeJS) (신입/경력)](https://www.notion.so/NodeJS-c3df214ebb28423092f6798122156c4d)
-  - [프론트엔드 개발자 (React / VanillaJS) (주니어경력 ~ 경력)](https://www.notion.so/React-VanillaJS-9f7029657eaa48ef814c057a1f8b4642)
+  - [백엔드 개발자 (NodeJS) (신입/경력)](https://inflab.notion.site/NodeJS-4a7668d2564a4180a0721a2135f97840)
+  - [프론트엔드 개발자 (React / VanillaJS) (경력)](https://inflab.notion.site/React-VanillaJS-297e778f28334a50b5e68b8a898de569)
 
 - [채용시까지] [[브런치/티스토리] Android 앱 개발자(1년차 이상)](https://careers.kakao.com/jobs/P-12234)
 - [채용시까지] [버즈빌 주니어 개발자 (서버/데이터/웹프론트/모바일) 채용](https://apply.workable.com/buzzvil/?lng=en)

--- a/db.json
+++ b/db.json
@@ -2,12 +2,12 @@
 	"recruits": [
     		{
 			"endDate": "수시채용",
-			"link": "https://www.notion.so/NodeJS-c3df214ebb28423092f6798122156c4d",
+			"link": "https://inflab.notion.site/NodeJS-4a7668d2564a4180a0721a2135f97840",
 			"description": "인프런 백엔드 개발자(NodeJS) 채용"
 		},
 		{
 			"endDate": "수시채용",
-			"link": "https://www.notion.so/React-VanillaJS-9f7029657eaa48ef814c057a1f8b4642",
+			"link": "https://inflab.notion.site/React-VanillaJS-297e778f28334a50b5e68b8a898de569",
 			"description": "인프런 프론트엔드 개발자(React / VanillaJS) 채용"
 		},
 		{


### PR DESCRIPTION
- 프론트엔드 개발자 경력만 포함하도록 변경하였습니다.
- 각 파트별 링크가 private 링크라 권한이 없다고 나와서 public 링크로 변경하였습니다.
- 하단 추천 도서 요약정리 링크가 이제는 존재하지 않아 지웠습니다. 작성자 분 계정 자체가 없어진거 같습니다. https://www.slideshare.net/ddayinhwang9