### PR TITLE
HitCount가 정상적으로 보이지 않는 문제 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![author](https://img.shields.io/badge/author-jojoldu-ff69b4.svg?style=flat-square)](https://jojoldu.tistory.com/)
 [![Build Status](https://travis-ci.org/jojoldu/junior-recruit-scheduler.svg?branch=master)](https://travis-ci.org/jojoldu/junior-recruit-scheduler)
 [![CONTRIBUTORS](https://img.shields.io/badge/contributors-25-green.svg?style=flat-square)](https://github.com/jojoldu/junior-recruit-scheduler/graphs/contributors)
-[![HitCount](http://hits.dwyl.io/jojoldu/junior-recruit-scheduler.svg)](http://hits.dwyl.io/jojoldu/junior-recruit-scheduler)
+[![HitCount](http://hits.dwyl.com/jojoldu/junior-recruit-scheduler.svg)](http://hits.dwyl.com/jojoldu/junior-recruit-scheduler)
 
 <a href="https://github.com/jojoldu/junior-recruit-scheduler/graphs/contributors"><img src="https://opencollective.com/junior-recruit-scheduler/contributors.svg?width=720"></a>
 


### PR DESCRIPTION
HitCount 이미지가 정상적으로 보이지 않아서 수정했는데, 사용해보지 않던 거라 간단하게 찾아보고 수정해서 적절한 수정인지 확신은 없네요.

다만 공식 페이지에서 알려주고 있는 방법이라 수정해봤어요.