### PR TITLE
그린랩스 채용공고 삭제 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@
   - [백엔드 개발자 (NodeJS) (신입/경력)](https://inflab.notion.site/NodeJS-4a7668d2564a4180a0721a2135f97840)
   - [프론트엔드 개발자 (React / VanillaJS) (신입/경력)](https://inflab.notion.site/React-VanillaJS-297e778f28334a50b5e68b8a898de569)
 
-- [채용시까지] [[그린랩스] 백엔드 개발 (신입 및 3년 이하)](https://greenlabs.co.kr/%EC%B1%84%EC%9A%A9%EA%B3%B5%EA%B3%A0/%ec%8b%a0%ec%84%a0%eb%a7%88%ec%bc%93%ea%b0%9c%eb%b0%9c%ec%8b%a4-%eb%b0%b1%ec%97%94%eb%93%9c-%ea%b0%9c%eb%b0%9c-%ec%8b%a0%ec%9e%85-%eb%b0%8f-3%eb%85%84-%ec%9d%b4%ed%95%98/)
-
 - [채용시까지] [[당근마켓] 당근미니 팀 R&D 엔지니어 인턴](https://team.daangn.com/jobs/5041198003/)
 
 - [채용시까지] [[브런치/티스토리] Android 앱 개발자(1년차 이상)](https://careers.kakao.com/jobs/P-12234)

--- a/data/db.json
+++ b/data/db.json
@@ -12,11 +12,6 @@
     },
     {
       "endDate": "채용시까지",
-      "link": "https://greenlabs.co.kr/%EC%B1%84%EC%9A%A9%EA%B3%B5%EA%B3%A0/%ec%8b%a0%ec%84%a0%eb%a7%88%ec%bc%93%ea%b0%9c%eb%b0%9c%ec%8b%a4-%eb%b0%b1%ec%97%94%eb%93%9c-%ea%b0%9c%eb%b0%9c-%ec%8b%a0%ec%9e%85-%eb%b0%8f-3%eb%85%84-%ec%9d%b4%ed%95%98/",
-      "description": "[그린랩스] 백엔드 개발 (신입 및 3년 이하)"
-    },
-    {
-      "endDate": "채용시까지",
       "link": "https://team.daangn.com/jobs/5041198003/",
       "description": "[당근마켓] 당근미니 팀 R&D 엔지니어 인턴"
     },


### PR DESCRIPTION
그린랩스 채용공고 클릭 시 "찾을 수 없는 페이지" 발생으로 삭제합니다.