### PR TITLE
네이버파이낸셜 2022 상반기 대졸 신입 공채

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 ### 추천 기업 (마감일)
 
 - [2022.04.07 00:00:00 ~ 2022.04.20 23:59:59] [버드뷰(화해) 백엔드 신입 공개채용](https://boards.greenhouse.io/birdview/jobs/4433435004)
+- [2022.04.25 00:00:00 ~ 2022.05.06 18:00:00] [네이버파이낸셜 2022 상반기 대졸 신입 공채](https://naverfincorp-career.com/nfin/job/detail/developer?annoId=20008110&classId=&jobId=&entTypeCd=&searchTxt=)
 
 ### 추천 기업 (수시 & 상시 채용)
 

--- a/data/db.json
+++ b/data/db.json
@@ -6,6 +6,11 @@
       "description": "버드뷰(화해) 백엔드 신입 공개채용"
     },
     {
+      "endDate": "2022.05.06 18:00:00",
+      "link": "https://naverfincorp-career.com/nfin/job/detail/developer?annoId=20008110&classId=&jobId=&entTypeCd=&searchTxt=",
+      "description": "네이버파이낸셜 2022 상반기 대졸 신입 공채"
+    },
+    {
       "endDate": "채용시까지",
       "link": "https://inflab.notion.site/NodeJS-4a7668d2564a4180a0721a2135f97840",
       "description": "인프런 백엔드 개발자(NodeJS) 채용"


### PR DESCRIPTION
네이버파이낸셜 2022 상반기 대졸 신입 공채 공고가 올라와서 PR을 올립니다.
Backend, Frontend, STA/RA 분석 3개 직군에서 모집합니다.