### PR TITLE
찾을 수 없는 Velog 채용 공고 링크 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@
 
 - [채용시까지] [인프런 - 백엔드 주니어 개발자](https://www.rallit.com/positions/1507/%EB%B0%B1%EC%97%94%EB%93%9C-%EA%B0%9C%EB%B0%9C%EC%9E%90-node-js-%EC%8B%A0%EC%9E%85-%EA%B2%BD%EB%A0%A5)
 
-- [채용시까지] [Velog - 풀스택 인턴](https://chaf.career.greetinghr.com/o/77046)
-
 - [채용시까지] [야놀자 - 채용연계형 인턴](https://www.rallit.com/positions/1434/software-engineering-intern-%EC%B1%84%EC%9A%A9-%EC%97%B0%EA%B3%84%ED%98%95-%EC%9D%B8%ED%84%B4)
 
 - [채용시까지] [그리팅 - 백오피스 엔지니어 (전환형 인턴)](https://www.rallit.com/positions/1466/%EA%B7%B8%EB%A6%AC%ED%8C%85-%EB%B0%B1%EC%98%A4%ED%94%BC%EC%8A%A4-%EC%97%94%EC%A7%80%EB%8B%88%EC%96%B4-%EC%A0%84%ED%99%98%ED%98%95-%EC%9D%B8%ED%84%B4)

--- a/data/db.json
+++ b/data/db.json
@@ -7,11 +7,6 @@
     }, 
     {
       "endDate": "채용시까지",
-      "link": "https://chaf.career.greetinghr.com/o/77046",
-      "description": "Velog 풀스택 인턴"
-    }, 
-    {
-      "endDate": "채용시까지",
       "link": "https://www.rallit.com/positions/1434/software-engineering-intern-%EC%B1%84%EC%9A%A9-%EC%97%B0%EA%B3%84%ED%98%95-%EC%9D%B8%ED%84%B4",
       "description": "야놀자 채용연계형 인턴"
     }, 


### PR DESCRIPTION
하단 이미지와 같이 404 에러를 반환하는 [Velog 채용 공고의 링크](https://chaf.career.greetinghr.com/o/77046)를 삭제하였습니다.

![image](https://github.com/jojoldu/junior-recruit-scheduler/assets/71889359/1be94120-99b3-4cc6-adbf-59e9f67dee4a)

